### PR TITLE
Fix various typos

### DIFF
--- a/PartOMagic/Base/Containers.py
+++ b/PartOMagic/Base/Containers.py
@@ -108,7 +108,7 @@ def getAllDependent(feat):
 
 def isContainer(obj):
     '''isContainer(obj): returns True if obj is an object container, such as 
-    Group, Part, Body. The important characterisic of an object being a 
+    Group, Part, Body. The important characteristic of an object being a 
     container is that it can be activated to receive new objects. Documents 
     are considered containers, too.'''
     

--- a/PartOMagic/Base/FilePlant/FCProject.py
+++ b/PartOMagic/Base/FilePlant/FCProject.py
@@ -110,7 +110,7 @@ class FCProject(object):
         return self._app_filelist + self._gui_filelist
         
     def fromStream(self, name, typeid, bs_app, bs_vp = None):
-        """Initializes this project from a stram of data of one object. 
+        """Initializes this project from a stream of data of one object. 
         Warning: this does not add an object to the project, - all existing objects will 
         be wiped, and the stramed object becomes the ONLY object of the project."""
         

--- a/PartOMagic/Features/AssyFeatures/MuxAssembly.py
+++ b/PartOMagic/Features/AssyFeatures/MuxAssembly.py
@@ -73,7 +73,7 @@ class MUX(Ghost):
         
         selfobj.IAm = 'PartOMagic.MUX'
         
-        selfobj.addProperty('App::PropertyBool','FlattenCompound',"MUX","If true, compound nesting does not follow nesting of Parts. If False, compound nesting follows nexting of parts.")
+        selfobj.addProperty('App::PropertyBool','FlattenCompound',"MUX","If true, compound nesting does not follow nesting of Parts. If False, compound nesting follows nesting of parts.")
         selfobj.addProperty('App::PropertyLinkListGlobal', 'ExclusionList', "MUX", 'List of objects to exclude from compound')
         selfobj.addProperty('App::PropertyEnumeration', 'Traversal', "MUX", 'Sets if to look for shapes in nested containers')
         selfobj.Traversal = ['Direct children', 'Recursive']

--- a/PartOMagic/Gui/Observer.py
+++ b/PartOMagic/Gui/Observer.py
@@ -111,9 +111,10 @@ class Observer(object):
         ac = activeContainer()
         aw = Gui.activeWorkbench().GetClassName()
         #hack!! we delay call of addObject to fire from within onChanged, as doing it now 
-        #results in incorrect parenting of viewproviders. Yet it has to be done before recompute, o
-        #therwise the recompute fails.
-        #From there, another delayed call is registered - a call to advanceTip, which should be called after the new object is fully set up.
+        #results in incorrect parenting of viewproviders. Yet it has to be done
+        #before recompute, otherwise the recompute fails.
+        #From there, another delayed call is registered - a call to advanceTip
+        #which should be called after the new object is fully set up.
         self.addition_calls_queue.append(
           lambda self=self, feature=feature, ac=ac, aw=aw:
             self.appendToActiveContainer(feature, ac, aw)
@@ -285,7 +286,7 @@ class Observer(object):
             try:
                 self.activeContainerChanged(last_ac, ac)
             finally:
-                # re-query the ative containers, as they might have been altered by setActiveContainer.
+                # re-query the active containers, as they might have been altered by setActiveContainer.
                 activeBody = Gui.ActiveDocument.ActiveView.getActiveObject("pdbody")
                 activePart = Gui.ActiveDocument.ActiveView.getActiveObject("part")
                 self.activeObjects[App.ActiveDocument.Name] = (ac, activePart, activeBody)


### PR DESCRIPTION
Found via `codespell -q 3 -L normaly,ro`