### PR TITLE
Make license match SPDX ID

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -5,7 +5,7 @@
   <version>1.1.0</version>
   <date>2023-03-29</date>
   <maintainer email="vv.titov@gmail.com">DeepSOIC</maintainer>
-  <license file="LICENSE">LGPLv2</license>
+  <license file="LICENSE">LGPL-2.0-or-later</license>
   <url type="repository" branch="master">https://github.com/DeepSOIC/Part-o-magic</url>
   <url type="repository" branch="release-v1.0.0">https://github.com/DeepSOIC/Part-o-magic</url>
   <url type="bugtracker">https://github.com/DeepSOIC/Part-o-magic/issues</url>


### PR DESCRIPTION
See https://spdx.org/licenses/ -- note that you might actually mean `LGPL-2.0-only`, in which case use that instead.
