### PR TITLE
ExpressionParser - Use raw strings to work with more modern Python versions

### DIFF
--- a/PartOMagic/Base/ExpressionParser.py
+++ b/PartOMagic/Base/ExpressionParser.py
@@ -15,8 +15,8 @@ def expressionDeps(expr, doc):
       self-references as objects, for example in '=Placement.Base.x' will list 'Placement' 
       as an object. """
     global namechars
-    startchars = set("+-*/(%^&\[<>;, =")
-    endchars = set(".")
+    startchars = set(r"+-*/(%^&\[<>;, =")
+    endchars = set(r".")
     
     if expr is None:
         return []


### PR DESCRIPTION
Raw strings are compatible with Python 3.9 to current stable covering all currently supported versions.